### PR TITLE
fix(scroll): correct infinite load issue by adjusting scrollHeight calculation

### DIFF
--- a/src/app/features/pokemon/pokemon-list/pokemon-list-home/pokemon-list-home.component.ts
+++ b/src/app/features/pokemon/pokemon-list/pokemon-list-home/pokemon-list-home.component.ts
@@ -31,8 +31,15 @@ export class PokemonListHomeComponent extends PokemonListComponent implements On
   // Écouteur d'événement de défilement
   @HostListener('window:scroll', ['$event'])
   onScroll(): void {
+
+    const scrollPosition = window.innerHeight + window.scrollY;
+    const threshold = document.documentElement.scrollHeight;
+
+    if (this.isLoading) return;
+
     // Vérifie si l'utilisateur est proche du bas de la page
-    if (window.innerHeight + window.scrollY >= document.body.offsetHeight - this.scrollThreshold) {
+    if (scrollPosition >= threshold) {
+      console.log("this.loadMorePokemons : ");
       this.loadMorePokemons();
     }
   }


### PR DESCRIPTION
This update addresses an issue where the `loadMorePokemons` function was being called repeatedly due to incorrect threshold calculation. The problem stemmed from using the viewport height instead of the document's total scrollable height. The fix involved changing the threshold to `document.documentElement.scrollHeight` to ensure that the function only triggers when the user reaches the bottom of the page.