### PR TITLE
fix(pokemon): correct attack loading on version change in details component

### DIFF
--- a/src/app/features/pokemon/pokemon-details/pokemon-details.component.ts
+++ b/src/app/features/pokemon/pokemon-details/pokemon-details.component.ts
@@ -189,13 +189,7 @@ export class PokemonDetailsComponent implements OnInit, OnChanges, OnDestroy {
   // Gère le changement de version sélectionnée
   onVersionChange(event: Event) {
     const selectElement = event.target as HTMLSelectElement;
-    const newVersion = selectElement.value;
-
-    // Vérifiez si la version sélectionnée est différente de l'actuelle
-    if (newVersion !== this.selectedVersion) {
-      this.selectedVersion = newVersion;
-      this.getMovesForSelectedVersion();
-    }
+    this.getMovesForSelectedVersion();
   }
 
   // Filtre les moves pour la version de jeu sélectionnée


### PR DESCRIPTION
This commit fixes a critical bug in the Pokémon Details component that affected how attack data was loaded when changing game versions. Previously, the component failed to properly reload attacks due to an unnecessary conditional check.

**Key Changes:**
- Removed the conditional check that prevented the reloading of attack data when the game version was switched.
- Ensured that attack data is now consistently and correctly reloaded whenever a user selects a different version, improving the accuracy and reliability of the displayed information.

This fix enhances the user experience by ensuring that the attack data on the Pokémon Details page is always accurate and reflects the selected game version.