### PR TITLE
fix(pokemon): correct alternative forms update

### DIFF
--- a/src/app/features/pokemon/pokemon-details/pokemon-details-global-informations/pokemon-details-global-informations.component.css
+++ b/src/app/features/pokemon/pokemon-details/pokemon-details-global-informations/pokemon-details-global-informations.component.css
@@ -77,6 +77,7 @@
     justify-content: space-between; /* Répartit les images avec un espace égal entre elles */
     align-items: center;          /* Centre les images verticalement dans le conteneur */
     gap: 20px;
+    max-width: 100%;
 }
 
 .container-alternative-form{
@@ -87,6 +88,12 @@
     align-items: center;
 
     gap: 4px;
+    flex: 1; /* Make each form take equal space */
+}
+
+/* Style for a single alternative form */
+.container-alternative-form.single-form {
+    max-width: 50%; /* Limit max width when only one form */
 }
 
 @media (max-width: 768px) {

--- a/src/app/features/pokemon/pokemon-details/pokemon-details-global-informations/pokemon-details-global-informations.component.html
+++ b/src/app/features/pokemon/pokemon-details/pokemon-details-global-informations/pokemon-details-global-informations.component.html
@@ -82,21 +82,22 @@
               </ng-template>
                 
               <!-- Contenu des formes alternatives -->
-              <ng-template *ngIf="alternativeForms.length!=1" appPokemonTabContent title="Alternative form(s)">
+              <ng-template *ngIf="this.alternativeForms && this.alternativeForms.length > 0" appPokemonTabContent title="Alternative form(s)">
 
                 <div class="container-tab-bar-informations">
 
                   <div class="container-alternative-forms" >
                     
-                    <div *ngFor="let form of alternativeForms" class="container-alternative-form" (click)="selectedAlternativeForm(form.id)">
+                    <div 
+                      *ngFor="let form of alternativeForms" 
+                      class="container-alternative-form" 
+                      (click)="selectedAlternativeForm(form.id)"
+                      [ngClass]="{'single-form': alternativeForms.length === 1}"
+                    >
                       
                       <!-- TODO : FAIRE UN COMPOSANT -->
-                      <div *ngIf="form.name!=pokemon.name">
-
-                        <p class="label-alternative-form">{{form.formattedName}}</p>
-                        <img [src]="form.officialArtwork" class="img-forms-alternative"/>
-
-                      </div>
+                      <p class="label-alternative-form">{{form.formattedName}}</p>
+                      <img [src]="form.officialArtwork" class="img-forms-alternative"/>
 
                     </div>
 

--- a/src/app/features/pokemon/pokemon-details/pokemon-details-global-informations/pokemon-details-global-informations.component.ts
+++ b/src/app/features/pokemon/pokemon-details/pokemon-details-global-informations/pokemon-details-global-informations.component.ts
@@ -20,7 +20,6 @@ export class PokemonDetailsGlobalInformationsComponent {
   // Charger un pokemon depuis une forme alternative
   @Output() selectPokemon = new EventEmitter<number>();
   selectedAlternativeForm(id: number): void {
-    console.log("test");
     this.selectPokemon.emit(id);
   }
 

--- a/src/app/features/pokemon/pokemon-details/pokemon-details.component.ts
+++ b/src/app/features/pokemon/pokemon-details/pokemon-details.component.ts
@@ -42,7 +42,7 @@ export class PokemonDetailsComponent implements OnInit, OnChanges, OnDestroy {
   tutorMovesMethod    : PokemonMove[] = [];             // Tableau pour stocker les attaques que peut apprendre le pokemon par un pnj
   eggMovesMethod      : PokemonMove[] = [];             // Tableau pour stocker les attaques que peut apprendre le pokemon par un pnj
   
-  @Input() pokemonId !: number;                 // ID du Pokémon actuel
+  @Input() pokemonId !: number;                         // ID du Pokémon actuel
   @Output() selectPokemon = new EventEmitter<number>();
 
 
@@ -160,7 +160,6 @@ export class PokemonDetailsComponent implements OnInit, OnChanges, OnDestroy {
       switchMap(pokemonSpecies => {
 
         // Filtrez pour exclure la forme de base en utilisant le nom du Pokémon
-
         const alternativeFormRequests = pokemonSpecies.varieties
 
           // Filtre les formes alternatives pour exclure la forme de base en utilisant le nom du Pokémon
@@ -171,16 +170,23 @@ export class PokemonDetailsComponent implements OnInit, OnChanges, OnDestroy {
             // Convertit les données brutes en une instance de la classe `Pokemon`
             switchMap(data => this.pokemonService.createPokemonFromDetail(data))
           ));
-
-        // Utilisation de `forkJoin` pour exécuter toutes les requêtes de formes alternatives en parallèle
-        return forkJoin(alternativeFormRequests).pipe(
+        
+        if (alternativeFormRequests.length === 0) {
+          // Définit `alternativeForms` comme un tableau vide si aucune forme alternative n'est trouvée
+          this.alternativeForms = [];
+          return of(pokemonSpecies);
           
-          // Assigne les formes alternatives récupérées à l'attribut de classe `alternativeForms`
-          tap(alternativeForms => this.alternativeForms = alternativeForms),
-          
-          // Retourne l'espèce de Pokémon après le traitement des formes alternatives
-          map(() => pokemonSpecies)
-        );
+        } else {
+          // Utilisation de `forkJoin` pour exécuter toutes les requêtes de formes alternatives en parallèle
+          return forkJoin(alternativeFormRequests).pipe(
+            
+            // Assigne les formes alternatives récupérées à l'attribut de classe `alternativeForms`
+            tap(alternativeForms => this.alternativeForms = alternativeForms),
+            
+            // Retourne l'espèce de Pokémon après le traitement des formes alternatives
+            map(() => pokemonSpecies)
+          );
+        }
       }),
   
       // Gestion des erreurs


### PR DESCRIPTION
This commit fixes a bug in the Pokémon detail view where the alternative forms of a Pokémon were not properly updated when switching between different Pokémon.

**Bug Fixes:**
- Added a condition to ensure that the `alternativeForms` attribute is correctly reset whenever a different Pokémon is selected, preventing stale data from being displayed.
- Adjusted the rendering logic for scenarios where only a single alternative form is available, enhancing the user experience by providing a more intuitive display.

**CSS and Layout Adjustments:**
- Replaced specific CSS classes to maintain a consistent layout with the new display logic for alternative forms, ensuring visual coherence across different states of the detail view.

These changes improve the accuracy and usability of the Pokémon detail view, providing a better experience when navigating between Pokémon with alternative forms.