### PR TITLE
fix(pokemon): handle unknown gender and improve gender ratio display

### DIFF
--- a/src/app/features/pokemon/pokemon-details/pokemon-details-global-informations/pokemon-details-global-informations.component.html
+++ b/src/app/features/pokemon/pokemon-details/pokemon-details-global-informations/pokemon-details-global-informations.component.html
@@ -60,21 +60,27 @@
                   <app-info-section title="Egg groups (Hatch time)" text="{{pokemonSpecies.eggGroups}} ({{pokemonSpecies.hatchCounter}} cycles)"/>
                   <app-info-section title="Growth rate"             text="{{growthRate.formattedName}}"/>
                   <app-info-section title="Gender rate">
-                      <div extra-content>
 
-                        <div class="progress-stacked">
+                    <div extra-content *ngIf="pokemonSpecies.genderRate != -1; else genderUnknown">
 
-                          <div class="progress-bar progress-bar-male" role="progressbar" [style.width.%]="(1 - pokemonSpecies.genderRate / 8) * 100"></div>
-                          <div class="progress-bar progress-bar-female" role="progressbar"  [style.width.%]="(pokemonSpecies.genderRate / 8) * 100" ></div>
-                          
-                        </div>
+                      <div class="progress-stacked">
 
-                        <div class="container-label-gender-rate">
-                          <p class="label-gender-rate-male">{{ (1 - pokemonSpecies.genderRate / 8) * 100 | number: '1.0-2' }}% Male</p>
-                          <p class="label-gender-rate-female">{{ (pokemonSpecies.genderRate / 8) * 100 | number: '1.0-2' }}% Female</p>
-                        </div>
-
+                        <div class="progress-bar progress-bar-male" role="progressbar" [style.width.%]="pokemonSpecies.percentageGenderRateMale"></div>
+                        <div class="progress-bar progress-bar-female" role="progressbar"  [style.width.%]="pokemonSpecies.percentageGenderRateFemale" ></div>
+                        
                       </div>
+
+                      <div class="container-label-gender-rate">
+                        <p class="label-gender-rate-male">{{ pokemonSpecies.percentageGenderRateMale | number: '1.0-2' }}% Male</p>
+                        <p class="label-gender-rate-female">{{ pokemonSpecies.percentageGenderRateFemale | number: '1.0-2' }}% Female</p>
+                      </div>
+
+                    </div>
+                    
+                    <ng-template #genderUnknown>
+                      <div class="gender-unknown">Gender unknown</div>
+                    </ng-template>
+
                   </app-info-section>
 
                 </div>

--- a/src/app/models/pokemon/pokemon-species/pokemon-species.ts
+++ b/src/app/models/pokemon/pokemon-species/pokemon-species.ts
@@ -160,6 +160,14 @@ export class PokemonSpecies {
     return this.habitatRessource?.name  ? capitalizeFirstLetter(this.habitatRessource?.name) : 'N/A';
   }
 
+  get percentageGenderRateMale(): number {
+    return (1 - this.genderRate / 8) * 100
+  }
+
+  get percentageGenderRateFemale(): number {
+    return (this.genderRate / 8) * 100
+  }
+
   get generationName() : string{ 
     const generationField = this.generationRessource.name;
     const generation = this.getGeneration(generationField);


### PR DESCRIPTION
This commit addresses issues related to the handling of Pokémon with an unknown gender and improves the display of gender ratios in the application.

**Bug Fixes and Gender Handling:**
- Added specific handling for Pokémon with an unknown gender. When the gender is set to -1, it is now correctly interpreted as "Gender unknown".
- Introduced a conditional block in the HTML template to manage cases where the gender is unknown, displaying "Gender unknown" instead of showing male and female percentages.

**Enhancements to Gender Ratio Display:**
- Updated the logic for calculating male and female gender ratios in the `PokemonSpecies` model, improving code readability and maintainability.
- Enhanced the display of gender ratio progress bars and labels for a clearer presentation, ensuring users can easily interpret the gender information of Pokémon.

These changes improve the accuracy and user experience related to Pokémon gender display, particularly in handling edge cases like unknown gender.