### PR TITLE
feat(pokemon): add base stats and weaknesses/resistances display

### DIFF
--- a/src/app/features/moves/damage-class/damage-class.component.css
+++ b/src/app/features/moves/damage-class/damage-class.component.css
@@ -1,3 +1,21 @@
+.container-type{
+    display: block;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    border-radius: 8px;
+
+    padding: 3px 6px;
+}
+
+.label-title{
+    color: var(--color-text-white);
+    font-family: var(--main-font-family);
+    font-size: 12px;
+    line-height:normal;
+    margin: 0;
+}
+
 .damage-physical {
     background-color: #c77b19;
     color: white;

--- a/src/app/features/moves/damage-class/damage-class.component.html
+++ b/src/app/features/moves/damage-class/damage-class.component.html
@@ -1,3 +1,3 @@
-<span class="badge text-capitalize" style="display: block;" [ngClass]="getDamageClass(damageClass)">
-    {{ damageClass ? getFormattedDamageClass() : '' }}
+<span class="container-type" [ngClass]="getDamageClass(damageClass)">
+    <p class="label-title">{{ damageClass ? getFormattedDamageClass() : '' }}</p>
 </span>

--- a/src/app/features/pokemon/pokemon-details/pokemon-base-stats/pokemon-base-stats.component.css
+++ b/src/app/features/pokemon/pokemon-details/pokemon-base-stats/pokemon-base-stats.component.css
@@ -1,0 +1,104 @@
+
+/************/
+/* CONAINER */
+/************/
+.container {
+    display: flex;
+    align-items: center; /* Vertically centers the content */
+    width: 100%; /* Full width to ensure space is distributed evenly */
+    padding: 0;
+}
+
+/*********/
+/* LABEL */
+/*********/
+.label-title{
+    flex: 2;
+
+    color: var(--color-text-secondary-grey);
+    font-family: var(--main-font-family);
+    font-size: 14px;
+    font-style: normal;
+    line-height: normal;
+}
+
+.label-value{
+    flex: 1;
+
+    color: var(--main-color-black);
+    font-family: var(--main-font-family);
+    font-size: 14px;
+    font-style: normal;
+    line-height: normal;
+}
+
+.label-value{
+    text-align:right;
+}
+
+/****************/
+/* PROGRESS BAR */
+/****************/
+.container-progress-bar {
+    flex: 3; 
+    padding-left: 8px;
+}
+
+.progress {
+    width: 100%; /* Full width for the progress container */
+    height: 6px;
+}
+
+.progress-bar.low {
+    background-color: red;
+}
+
+.progress-bar.medium-low {
+    background-color: rgb(255, 123, 0);
+}
+
+.progress-bar.medium-hight {
+    background-color: #FAC200;
+}
+
+.progress-bar.high {
+    background-color: green;
+}
+
+.full-text {
+    display: inline;
+}
+
+.short-text {
+    display: none;
+}
+
+@media (max-width: 1050px) {
+    .full-text {
+        display: none;
+    }
+
+    .short-text {
+        display: inline;
+    }
+}
+
+@media (max-width: 767px) {
+    .full-text {
+        display: inline;
+    }
+
+    .short-text {
+        display: none;
+    }
+}
+
+@media (max-width: 380px) {
+    .full-text {
+        display: none;
+    }
+
+    .short-text {
+        display: inline;
+    }
+}

--- a/src/app/features/pokemon/pokemon-details/pokemon-base-stats/pokemon-base-stats.component.html
+++ b/src/app/features/pokemon/pokemon-details/pokemon-base-stats/pokemon-base-stats.component.html
@@ -1,0 +1,24 @@
+<div class="container">
+
+    <div class="label-title">
+      <span class="full-text">{{displayFullStatName(title)}}</span>
+      <span class="short-text">{{displayShortStatName(title)}}</span>
+    </div>
+
+    <div class="label-value">{{ value }}</div>
+
+    <div class="container-progress-bar">
+
+      <div class="progress">
+        <div
+          class="progress-bar"
+          role="progressbar"
+          [style.width.%]="(value / 255) * 100"
+          [ngClass]="getProgressBarClass(value)"
+        ></div>
+      </div>
+      
+    </div>
+
+  </div>
+  

--- a/src/app/features/pokemon/pokemon-details/pokemon-base-stats/pokemon-base-stats.component.spec.ts
+++ b/src/app/features/pokemon/pokemon-details/pokemon-base-stats/pokemon-base-stats.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PokemonBaseStatsComponent } from './pokemon-base-stats.component';
+
+describe('PokemonBaseStatsComponent', () => {
+  let component: PokemonBaseStatsComponent;
+  let fixture: ComponentFixture<PokemonBaseStatsComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [PokemonBaseStatsComponent]
+    });
+    fixture = TestBed.createComponent(PokemonBaseStatsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/pokemon/pokemon-details/pokemon-base-stats/pokemon-base-stats.component.ts
+++ b/src/app/features/pokemon/pokemon-details/pokemon-base-stats/pokemon-base-stats.component.ts
@@ -1,0 +1,71 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-pokemon-base-stats',
+  templateUrl: './pokemon-base-stats.component.html',
+  styleUrls: ['./pokemon-base-stats.component.css']
+})
+export class PokemonBaseStatsComponent {
+
+  @Input() title : string = "";
+  @Input() value : number = 0;
+
+  displayFullStatName(title: string): string {
+    switch (title) {
+      case 'hp':
+        return 'HP';
+      case 'attack':
+        return 'Attack';
+      case 'defense':
+        return 'Defense';
+      case 'special-attack':
+        return 'Special Attack';
+      case 'special-defense':
+        return 'Special Defense';
+      case 'speed':
+        return 'Speed';
+      default:
+        return '';  // Retourne une chaîne vide si l'attribut ne correspond à aucun cas
+    }
+  }
+
+  displayShortStatName(title: string): string {
+    switch (title) {
+      case 'hp':
+        return 'HP';
+      case 'attack':
+        return 'Att.';
+      case 'defense':
+        return 'Def.';
+      case 'special-attack':
+        return 'Spe. Att.';
+      case 'special-defense':
+        return 'Spe. Def.';
+      case 'speed':
+        return 'Speed';
+      default:
+        return '';  // Retourne une chaîne vide si l'attribut ne correspond à aucun cas
+    }
+  }
+  
+
+  // Method to determine the progress bar color class
+  getProgressBarClass(value: number): string {
+
+    const percentage = (value / 255) * 100;
+
+    if (percentage < 20) {
+      return 'low';
+
+    } else if (percentage >= 20 && percentage < 40) {
+      return 'medium-low';
+
+    } else if (percentage >= 40 && percentage < 60) {
+      return 'medium-hight';
+
+    } else {
+      return 'high';
+    }
+  }
+
+}

--- a/src/app/features/pokemon/pokemon-details/pokemon-details-global-informations/pokemon-details-global-informations.component.css
+++ b/src/app/features/pokemon/pokemon-details/pokemon-details-global-informations/pokemon-details-global-informations.component.css
@@ -96,21 +96,9 @@
     max-width: 50%; /* Limit max width when only one form */
 }
 
-@media (max-width: 768px) {
-
-    .container-description-img {
-      flex-direction: column;    /* Passe les conteneurs en colonne sur les écrans de moins de 768px de large */
-    }
-  
-    .container-img, .container-tab-bar {
-      flex: 1 1 100%;            /* Chaque conteneur prend 100% de la largeur du parent sur les petits écrans */
-      width: 100%;
-    }
-}
-
-/*
+/********
     IMAGE
-*/
+*********/
 .img-pokemon, .blur {
     max-width: 100%;  /* L'image ne sera jamais plus large que 100% de son conteneur */
     height: auto;     /* La hauteur s'ajuste automatiquement pour maintenir le ratio d'aspect */
@@ -171,6 +159,10 @@
     font-style: normal;
 }
 
+.progress-stacked {
+    width: 100%; /* Full width for the progress container */
+    height: 6px;
+}
 
 .progress-bar-male{
     background-color: blue;
@@ -178,4 +170,20 @@
 
 .progress-bar-female{
     background-color: pink;
+}
+
+/***************/
+/* MEDIA QUERY */
+/***************/
+
+@media (max-width: 768px) {
+
+    .container-description-img {
+      flex-direction: column;    /* Passe les conteneurs en colonne sur les écrans de moins de 768px de large */
+    }
+  
+    .container-img, .container-tab-bar {
+      flex: 1 1 100%;            /* Chaque conteneur prend 100% de la largeur du parent sur les petits écrans */
+      width: 100%;
+    }
 }

--- a/src/app/features/pokemon/pokemon-details/pokemon-details-global-informations/pokemon-details-tabs-informations/info-section/info-section.component.css
+++ b/src/app/features/pokemon/pokemon-details/pokemon-details-global-informations/pokemon-details-tabs-informations/info-section/info-section.component.css
@@ -17,7 +17,7 @@
 }
 
 .label-title{
-    color: #888;
+    color: var(--color-title-grey);
     font-size: 14px;
 }
 

--- a/src/app/features/pokemon/pokemon-details/pokemon-details.component.css
+++ b/src/app/features/pokemon/pokemon-details/pokemon-details.component.css
@@ -1,3 +1,66 @@
+.container{
+    display: flex;
+    flex-direction: column;
+    gap: 120px;
+    align-self: stretch;
+}
+
+.container-weakness-stats{
+    display: flex;
+    align-items: flex-start;
+    align-content: flex-start;
+    gap: 60px;
+    align-self: stretch;
+    flex-wrap: wrap;
+}
+
+.container-weakness, .container-stats{
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+
+    flex-grow: 1;
+    flex-shrink: 0;
+    flex-basis: 0;
+}
+
+.container-weakness{
+    display: block;
+}
+
+.container-stats{
+}
+
+.container-base-stats{
+    display: flex;
+    flex-direction: column;
+
+    width: 100%;
+}
+
+.container-evolution{
+    width: 100%;          /* Largeur du conteneur */
+    overflow-x: auto;     /* Active le défilement horizontal si nécessaire */
+    white-space: nowrap;  /* Empêche le retour à la ligne du contenu à l'intérieur du conteneur */
+}
+
+.label-title-weakness, .label-title-stats{
+    align-self: stretch;
+    color: var(--main-color-black);
+    font-family: var(--main-font-family);
+    font-size: 20px;
+    font-style: normal;
+    line-height: normal;
+    margin: 0;
+}
+
+.label-title-weakness{
+}
+
+.label-title-stats{
+}
+
 table th {
     text-align: center;
 }
@@ -14,15 +77,37 @@ table td:first-child {
     text-align: left;
 }
 
-.container{
-    display: flex;
-    flex-direction: column;
-    gap: 120px;
-    align-self: stretch;
+/***************/
+/* MEDIA QUERY */
+/***************/
+/*  CF pokemon-weaknesses.component */
+@media (max-width: 882px) {
+    .label-title-stats{font-size: 19px;}
+}
+@media (max-width: 846px) {
+    .label-title-stats{font-size: 18px;}
+}
+@media (max-width: 810px) {
+    .label-title-stats{font-size: 17px;}
+}
+@media (max-width: 773px) {
+    .label-title-stats{font-size: 16px;}
 }
 
-.container-evolution{
-    width: 100%;          /* Largeur du conteneur */
-    overflow-x: auto;     /* Active le défilement horizontal si nécessaire */
-    white-space: nowrap;  /* Empêche le retour à la ligne du contenu à l'intérieur du conteneur */
+@media (max-width: 768px) {
+
+    .container{
+        gap: 96px;
+    }
+
+    .container-weakness-stats {
+      flex-direction: column;    /* Passe les conteneurs en colonne sur les écrans de moins de 768px de large */
+    }
+  
+    .container-weakness, .container-stats {
+      flex: 1 1 100%;            /* Chaque conteneur prend 100% de la largeur du parent sur les petits écrans */
+      width: 100%;
+    }
+
+    .label-title-stats{font-size: 20px;}
 }

--- a/src/app/features/pokemon/pokemon-details/pokemon-details.component.html
+++ b/src/app/features/pokemon/pokemon-details/pokemon-details.component.html
@@ -10,7 +10,29 @@
     />
 
     <!-- SENSIBILITES & STAT DE BASE -->
-    <div>
+    <div class="container-weakness-stats">
+
+        <div class="container-weakness">
+
+            <app-pokemon-weaknesses [weaknessesAndResistances]="weaknessesAndResistances"/>
+            
+        </div>
+
+        <div class="container-stats">
+
+            <p class="label-title-stats">Base stats</p>
+
+            <div class="container-base-stats">
+                <app-pokemon-base-stats 
+                    *ngFor="let stats of pokemon.stats"
+                    [title]="stats.stat.name"
+                    [value]="stats.baseStat"
+                />
+            </div>
+            
+
+        </div>
+
     </div>
 
 

--- a/src/app/features/pokemon/pokemon-details/pokemon-details.component.ts
+++ b/src/app/features/pokemon/pokemon-details/pokemon-details.component.ts
@@ -31,6 +31,7 @@ export class PokemonDetailsComponent implements OnInit, OnChanges, OnDestroy {
   alternativeForms    !: Pokemon[];                     // Objet avec les formes alternatives
   pokemonSpecies      !: PokemonSpecies;                // Objet Pokémon contenant les détails plus avancés
   growthRate          !: GrowthRate;                    // Autre détails du pokemon 
+  weaknessesAndResistances: { [type: string]: number } = {};
 
   gameVersions        : string[] = [];                  // Liste des versions de jeu disponibles
   selectedVersion     : string = '';                    // Version de jeu actuellement sélectionnée
@@ -186,6 +187,21 @@ export class PokemonDetailsComponent implements OnInit, OnChanges, OnDestroy {
             // Retourne l'espèce de Pokémon après le traitement des formes alternatives
             map(() => pokemonSpecies)
           );
+        }
+      }),
+
+      // Récupérer les faiblesses et résistances après avoir récupéré les formes alternatives
+      switchMap(() => {
+
+        if (this.pokemon) {
+
+          return this.pokemonService.getPokemonWeaknessesAndResistances(this.pokemon).pipe(
+
+            tap(weaknessesAndResistances => {this.weaknessesAndResistances = weaknessesAndResistances || {}}),
+            map(() => this.pokemonSpecies) // Continue avec l'espèce du Pokémon comme résultat
+          );
+        } else {
+          return of(this.pokemonSpecies); // Si `this.pokemon` est null, retournez l'espèce
         }
       }),
   

--- a/src/app/features/pokemon/pokemon-details/pokemon-weaknesses/pokemon-weaknesses.component.css
+++ b/src/app/features/pokemon/pokemon-details/pokemon-weaknesses/pokemon-weaknesses.component.css
@@ -1,0 +1,160 @@
+.container{
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+    gap: 16px;
+}
+
+
+.container-data{
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    align-self: stretch;
+}
+
+.container-title-subtitle{
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
+
+.container-subtitle{
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+}
+
+.container-types{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    gap: 8px;
+}
+
+
+.label-title{
+    align-self: stretch;
+    color: var(--main-color-black);
+    font-family: var(--main-font-family);
+    font-size: 20px;
+    font-style: normal;
+    line-height: normal;
+    padding: 0;
+    margin: 0;
+}
+
+.label-subtitle{
+    align-self: stretch;
+    color: var(--color-text-secondary-grey);
+    font-family: var(--main-font-family);
+    font-size: 14px;
+    font-style: normal;
+    line-height: normal;
+    text-align: center;
+    margin: 0;
+}
+
+/* Default display: show full text, hide short text */
+.full-text {
+    display: inline;
+}
+
+.short-text {
+    display: none;
+}
+
+.very-short-text {
+    display: none;
+}
+
+/* Media query to adjust text on smaller screens */
+@media (max-width: 1100px) {
+    .full-text {
+        display: none;
+    }
+
+    .short-text {
+        display: inline;
+    }
+
+    .very-short-text {
+        display: none;
+    }
+}
+
+@media (max-width: 900px) {
+    .full-text {
+        display: none;
+    }
+
+    .short-text {
+        display: none;
+    }
+
+    .very-short-text {
+        display: inline;
+    }
+}
+
+/* EVITER QUE LE TITRE NE SOIT COUPE */
+@media (max-width: 882px) {
+ .label-title{font-size: 19px;}
+}
+@media (max-width: 846px) {
+    .label-title{font-size: 18px;}
+}
+@media (max-width: 810px) {
+    .label-title{font-size: 17px;}
+}
+@media (max-width: 773px) {
+    .label-title{font-size: 16px;}
+}
+
+
+
+@media (max-width: 767px) {
+    .label-title{font-size: 20px;}
+
+    .full-text {
+        display: inline;
+    }
+
+    .short-text {
+        display: none;
+    }
+
+    .very-short-text {
+        display: none;
+    }
+}
+
+@media (max-width: 400px) {
+    .full-text {
+        display: none;
+    }
+
+    .short-text {
+        display: inline;
+    }
+
+    .very-short-text {
+        display: none;
+    }
+}
+
+@media (max-width: 343px) {
+    .full-text {
+        display: none;
+    }
+
+    .short-text {
+        display: none;
+    }
+    
+    .very-short-text {
+        display: inline;
+    }
+}

--- a/src/app/features/pokemon/pokemon-details/pokemon-weaknesses/pokemon-weaknesses.component.html
+++ b/src/app/features/pokemon/pokemon-details/pokemon-weaknesses/pokemon-weaknesses.component.html
@@ -1,0 +1,109 @@
+<div class="container">
+    
+    <p class="label-title">Weaknesses and Resistances</p>
+    
+    <div class="container-data">
+
+        <div class="container-subtitle">
+
+            <div class="container-title-subtitle">
+                <p class="label-subtitle">
+                    <span class="full-text">Very resistant</span>
+                    <span class="short-text">Very R.</span>
+                    <span class="very-short-text">Very R.</span>
+                </p>
+                <p class="label-subtitle">(/4)</p>
+            </div>
+            
+            <div class="container-types">
+                <app-pokemon-type 
+                    *ngFor="let type of categorizedWeaknesses.veryResistant"
+                    [type]="type"
+                />
+            </div>
+
+        </div>
+        
+        <div class="container-subtitle">
+
+            <div class="container-title-subtitle">
+                <p class="label-subtitle">
+                    <span class="full-text">Resistant</span>
+                    <span class="short-text">Resistant</span>
+                    <span class="very-short-text">Res.</span>
+                </p>
+                <p class="label-subtitle">(/2)</p>
+            </div>
+            
+            <div class="container-types">
+                <app-pokemon-type 
+                    *ngFor="let type of categorizedWeaknesses.resistant"
+                    [type]="type"
+                />
+            </div>
+
+        </div>
+    
+        <div class="container-subtitle">
+
+            <div class="container-title-subtitle">
+                <p class="label-subtitle">
+                    <span class="full-text">Immune</span>
+                    <span class="short-text">Immune</span>
+                    <span class="very-short-text">Imm.</span>
+                </p>
+                <p class="label-subtitle">(x0)</p>
+            </div>
+
+            <div class="container-types">
+                <app-pokemon-type 
+                    *ngFor="let type of categorizedWeaknesses.immune"
+                    [type]="type"
+                />
+            </div>
+
+        </div>
+
+        <div class="container-subtitle">
+
+            <div class="container-title-subtitle">
+                <p class="label-subtitle">
+                    <span class="full-text">Weak</span>
+                    <span class="short-text">Weak</span>
+                    <span class="very-short-text">W.</span>
+                </p>
+                <p class="label-subtitle">(x2)</p>
+            </div>
+            
+            <div class="container-types">
+                <app-pokemon-type 
+                    *ngFor="let type of categorizedWeaknesses.weak"
+                    [type]="type"
+                />
+            </div>
+        
+        </div>
+    
+        <div class="container-subtitle">
+
+            <div class="container-title-subtitle">
+                <p class="label-subtitle">
+                    <span class="full-text">Very Weak</span>
+                    <span class="short-text">Very W.</span>
+                    <span class="very-short-text">Very W.</span>
+                </p>
+                <p class="label-subtitle">(x4)</p>
+            </div>
+
+            <div class="container-types">
+                <app-pokemon-type 
+                    *ngFor="let type of categorizedWeaknesses.veryWeak"
+                    [type]="type"
+                />
+            </div>
+
+        </div>
+
+    </div>
+
+</div>

--- a/src/app/features/pokemon/pokemon-details/pokemon-weaknesses/pokemon-weaknesses.component.spec.ts
+++ b/src/app/features/pokemon/pokemon-details/pokemon-weaknesses/pokemon-weaknesses.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PokemonWeaknessesComponent } from './pokemon-weaknesses.component';
+
+describe('PokemonWeaknessesComponent', () => {
+  let component: PokemonWeaknessesComponent;
+  let fixture: ComponentFixture<PokemonWeaknessesComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [PokemonWeaknessesComponent]
+    });
+    fixture = TestBed.createComponent(PokemonWeaknessesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/pokemon/pokemon-details/pokemon-weaknesses/pokemon-weaknesses.component.ts
+++ b/src/app/features/pokemon/pokemon-details/pokemon-weaknesses/pokemon-weaknesses.component.ts
@@ -1,0 +1,53 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-pokemon-weaknesses',
+  templateUrl: './pokemon-weaknesses.component.html',
+  styleUrls: ['./pokemon-weaknesses.component.css']
+})
+export class PokemonWeaknessesComponent {
+
+  @Input() weaknessesAndResistances!: { [type: string]: number };
+
+  // Explicitly define the types of the arrays
+  categorizedWeaknesses: {
+    veryResistant: string[];
+    resistant: string[];
+    immune: string[];
+    veryWeak: string[];
+    weak: string[];
+  } = {
+    veryResistant: [],
+    resistant: [],
+    immune: [],
+    veryWeak: [],
+    weak: [],
+  };
+
+  ngOnInit(): void {
+    this.categorizeWeaknesses();
+  }
+
+  categorizeWeaknesses() {
+
+    for (const [type, multiplier] of Object.entries(this.weaknessesAndResistances)) {
+
+      if (multiplier === 0.25) {
+        this.categorizedWeaknesses.veryResistant.push(type);
+        
+      } else if (multiplier === 0.5) {
+        this.categorizedWeaknesses.resistant.push(type);
+
+      } else if (multiplier === 0) {
+        this.categorizedWeaknesses.immune.push(type);
+
+      } else if (multiplier === 4) {
+        this.categorizedWeaknesses.veryWeak.push(type);
+
+      } else if (multiplier === 2) {
+        this.categorizedWeaknesses.weak.push(type);
+      }
+    }
+  }
+
+}

--- a/src/app/features/pokemon/pokemon-summary/pokemon-summary-card/pokemon-summary-card.component.css
+++ b/src/app/features/pokemon/pokemon-summary/pokemon-summary-card/pokemon-summary-card.component.css
@@ -1,0 +1,13 @@
+.container-types{
+    display:flex ;
+    justify-content: center;
+    align-items: center;
+
+    gap: 8px;
+}
+
+.container-type{
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+}

--- a/src/app/features/pokemon/pokemon-summary/pokemon-summary-card/pokemon-summary-card.component.html
+++ b/src/app/features/pokemon/pokemon-summary/pokemon-summary-card/pokemon-summary-card.component.html
@@ -26,15 +26,15 @@
     <!-- TYPES -->
     <div class="row mt-3">
         
-        <div class="col-12">
+        <div class="col-12" style="padding: 0;">
 
-            <div class="row justify-content-between">
+            <div class="container-types">
 
-                <div class="col-6">
+                <div class="container-type">
                     <app-pokemon-type [type]="pokemon.typesName1"></app-pokemon-type>
                 </div>
 
-                <div class="col-6">
+                <div class="container-type">
                     <app-pokemon-type *ngIf="pokemon.types2" [type]="pokemon.typesName2"></app-pokemon-type>
                 </div>
                 

--- a/src/app/features/pokemon/pokemon.module.ts
+++ b/src/app/features/pokemon/pokemon.module.ts
@@ -16,6 +16,8 @@ import { PokemonSummaryCardEvolutionComponent } from './pokemon-summary/pokemon-
 import { PokemonListEvolutionComponent } from './pokemon-list/pokemon-list-evolution/pokemon-list-evolution.component';
 import { PokemonDetailsGlobalInformationsComponent } from './pokemon-details/pokemon-details-global-informations/pokemon-details-global-informations.component';
 import { InfoSectionComponent } from './pokemon-details/pokemon-details-global-informations/pokemon-details-tabs-informations/info-section/info-section.component';
+import { PokemonWeaknessesComponent } from './pokemon-details/pokemon-weaknesses/pokemon-weaknesses.component';
+import { PokemonBaseStatsComponent } from './pokemon-details/pokemon-base-stats/pokemon-base-stats.component';
 
 @NgModule({
   declarations: [
@@ -30,6 +32,8 @@ import { InfoSectionComponent } from './pokemon-details/pokemon-details-global-i
     PokemonListEvolutionComponent,
     PokemonDetailsGlobalInformationsComponent,
     InfoSectionComponent,
+    PokemonBaseStatsComponent,
+    PokemonWeaknessesComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/interfaces/pokemon/stat.ts
+++ b/src/app/interfaces/pokemon/stat.ts
@@ -1,0 +1,28 @@
+import { IAPIResource, IName, INamedAPIResource } from "../utility/common-models/common-models";
+
+export interface IStat {
+    id                  : number;                   // The identifier for this resource.
+    name                : string;                   // The name for this resource.
+    game_index          : number;                   // ID the games use for this stat.
+    is_battle_only      : boolean;                  // Whether this stat only exists within a battle.
+    affecting_moves     : IMoveStatAffectSets;      // A detail of moves which affect this stat positively or negatively.
+    affecting_natures   : INatureStatAffectSets;    // A detail of natures which affect this stat positively or negatively.
+    characteristics     : IAPIResource[];           // A list of characteristics that are set on a Pokémon when its highest base stat is this stat.
+    move_damage_class   : INamedAPIResource;        // The class of damage this stat is directly related to.
+    names               : IName[];                  // The name of this resource listed in different languages.
+}
+
+export interface IMoveStatAffectSets {
+    increase: IMoveStatAffect[];  // A list of moves and how they change the referenced stat positively.
+    decrease: IMoveStatAffect[];  // A list of moves and how they change the referenced stat negatively.
+}
+
+export interface IMoveStatAffect {
+    change  : number;               // The maximum amount of change to the referenced stat.
+    move    : INamedAPIResource;    // The move causing the change.
+}
+  
+export interface INatureStatAffectSets {
+    increase: INamedAPIResource[];  // A list of natures and how they change the referenced stat positively.
+    decrease: INamedAPIResource[];  // A list of natures and how they change the referenced stat negatively.
+}

--- a/src/app/interfaces/pokemon/types.ts
+++ b/src/app/interfaces/pokemon/types.ts
@@ -1,0 +1,37 @@
+import { IGenerationGameIndex, IName, INamedAPIResource } from "../utility/common-models/common-models";
+
+// Interface for Type (main interface for type resource)
+export interface IType {
+    id                      : number;                   // The identifier for this resource
+    name                    : string;                   // The name for this resource
+    damage_relations        : ITypeRelations;           // Details of how effective this type is toward others and vice versa
+    past_damage_relations   : ITypeRelationsPast[];     // List of details of how effective this type was toward others in previous generations
+    game_indices            : IGenerationGameIndex[];   // List of game indices relevant to this type by generation
+    generation              : INamedAPIResource;        // The generation this type was introduced in
+    move_damage_class       : INamedAPIResource;        // The class of damage inflicted by this type
+    names                   : IName[];                  // The name of this resource listed in different languages
+    pokemon                 : ITypePokemon[];           // List of details of Pokémon that have this type
+    moves                   : INamedAPIResource[];      // List of moves that have this type
+}
+
+// Interface for TypePokemon (details of Pokémon that have this type)
+export interface ITypePokemon {
+    slot: number;
+    pokemon: INamedAPIResource; // Reference to a Pokémon resource
+}
+
+// Interface for TypeRelations (damage relations for the type)
+export interface ITypeRelations {
+    no_damage_to        : INamedAPIResource[];  // Types this type has no effect on
+    half_damage_to      : INamedAPIResource[];  // Types this type is not very effective against
+    double_damage_to    : INamedAPIResource[];  // Types this type is very effective against
+    no_damage_from      : INamedAPIResource[];  // Types that have no effect on this type
+    half_damage_from    : INamedAPIResource[];  // Types that are not very effective against this type
+    double_damage_from  : INamedAPIResource[];  // Types that are very effective against this type
+}
+
+// Interface for TypeRelationsPast (damage relations in previous generations)
+export interface ITypeRelationsPast {
+    generation: INamedAPIResource; // Reference to the last generation for these damage relations
+    damage_relations: ITypeRelations; // The damage relations up to and including the listed generation
+}

--- a/src/app/interfaces/utility/common-models/common-models.ts
+++ b/src/app/interfaces/utility/common-models/common-models.ts
@@ -51,3 +51,9 @@ export interface IMachineVersionDetail {
     machine: IAPIResource;
     version_group: INamedAPIResource;
 }
+
+// Interface for GenerationGameIndex (game index relevant to a generation)
+export interface IGenerationGameIndex {
+    game_index: number;
+    generation: INamedAPIResource; // Reference to a generation resource
+}

--- a/src/app/mappers/pokemon/stats/move-stat-affect-sets.mapper.ts
+++ b/src/app/mappers/pokemon/stats/move-stat-affect-sets.mapper.ts
@@ -1,0 +1,14 @@
+import { MoveStatAffectSets } from "src/app/models/pokemon/stats/move-stat-affect-sets";
+import { MoveStatAffectMapper } from "./move-stat-affect.mapper";
+import { IMoveStatAffectSets } from "src/app/interfaces/pokemon/stat";
+
+export class MoveStatAffectSetsMapper {
+  
+    static mapData(data: IMoveStatAffectSets): MoveStatAffectSets {
+
+        return new MoveStatAffectSets(
+            MoveStatAffectMapper.mapDatas(data.increase),
+            MoveStatAffectMapper.mapDatas(data.decrease)
+        )
+    }
+}

--- a/src/app/mappers/pokemon/stats/move-stat-affect.mapper.ts
+++ b/src/app/mappers/pokemon/stats/move-stat-affect.mapper.ts
@@ -1,0 +1,18 @@
+import { MoveStatAffect } from "src/app/models/pokemon/stats/move-stat-affect";
+import { ApiRessourceMapper } from "../../utility/common-models/api-ressource.mapper";
+import { IMoveStatAffect } from "src/app/interfaces/pokemon/stat";
+
+export class MoveStatAffectMapper {
+  
+    static mapData(data: IMoveStatAffect): MoveStatAffect {
+
+        return new MoveStatAffect(
+            data.change,
+            ApiRessourceMapper.mapToNamedAPIResource(data.move)
+        );
+    }
+
+    static mapDatas(data: IMoveStatAffect[]): MoveStatAffect[] {
+        return data.map(MoveStatAffectMapper.mapData);
+    }
+}

--- a/src/app/mappers/pokemon/stats/nature-stat-affect-sets.mapper.ts
+++ b/src/app/mappers/pokemon/stats/nature-stat-affect-sets.mapper.ts
@@ -1,0 +1,14 @@
+import { NatureStatAffectSets } from "src/app/models/pokemon/stats/nature-stat-affect-sets";
+import { ApiRessourceMapper } from "../../utility/common-models/api-ressource.mapper";
+import { INatureStatAffectSets } from "src/app/interfaces/pokemon/stat";
+
+export class NatureStatAffectSetsMapper {
+  
+    static mapData(data: INatureStatAffectSets): NatureStatAffectSets {
+
+        return new NatureStatAffectSets(
+            ApiRessourceMapper.mapToNamedAPIResources(data.increase),
+            ApiRessourceMapper.mapToNamedAPIResources(data.decrease)
+        )
+    }
+}

--- a/src/app/mappers/pokemon/stats/stat.mapper.ts
+++ b/src/app/mappers/pokemon/stats/stat.mapper.ts
@@ -1,0 +1,24 @@
+import { Stat } from "src/app/models/pokemon/stats/stat";
+import { ApiRessourceMapper } from "../../utility/common-models/api-ressource.mapper";
+import { NameMapper } from "../../utility/common-models/name.mapper";
+import { MoveStatAffectSetsMapper } from "./move-stat-affect-sets.mapper";
+import { NatureStatAffectSetsMapper } from "./nature-stat-affect-sets.mapper";
+import { IStat } from "src/app/interfaces/pokemon/stat";
+
+export class StatMapper {
+  
+    static mapData(data: IStat): Stat {
+
+        return new Stat(
+            data.id,
+            data.name,
+            data.game_index,
+            data.is_battle_only,
+            MoveStatAffectSetsMapper.mapData(data.affecting_moves),
+            NatureStatAffectSetsMapper.mapData(data.affecting_natures),
+            ApiRessourceMapper.mapToAPIResources(data.characteristics),
+            ApiRessourceMapper.mapToNamedAPIResource(data.move_damage_class),
+            NameMapper.mapNames(data.names),
+        )
+    }
+}

--- a/src/app/mappers/pokemon/types/type-pokemon.mapper.ts
+++ b/src/app/mappers/pokemon/types/type-pokemon.mapper.ts
@@ -1,0 +1,20 @@
+import { ITypePokemon } from "src/app/interfaces/pokemon/types";
+import { TypePokemon } from "src/app/models/pokemon/types/type-pokemon";
+import { ApiRessourceMapper } from "../../utility/common-models/api-ressource.mapper";
+
+export class TypePokemonMapper {
+
+    static mapData(data: ITypePokemon): TypePokemon {
+
+        return new TypePokemon(
+            data.slot,
+            ApiRessourceMapper.mapToNamedAPIResource(data.pokemon)
+        );
+
+    }
+  
+    static mapDatas(data: ITypePokemon[]): TypePokemon[] {
+        return data.map(item => this.mapData(item));
+    }
+  }
+  

--- a/src/app/mappers/pokemon/types/type-relations-past.mapper.ts
+++ b/src/app/mappers/pokemon/types/type-relations-past.mapper.ts
@@ -1,0 +1,21 @@
+import { ITypeRelationsPast } from "src/app/interfaces/pokemon/types";
+import { TypeRelationsPast } from "src/app/models/pokemon/types/type-relations-past";
+import { ApiRessourceMapper } from "../../utility/common-models/api-ressource.mapper";
+import { TypeRelationsMapper } from "./type-relations.mapper";
+
+export class TypeRelationsPastMapper {
+
+    static mapData(data: ITypeRelationsPast): TypeRelationsPast {
+
+        return new TypeRelationsPast(
+            ApiRessourceMapper.mapToNamedAPIResource(data.generation),
+            TypeRelationsMapper.mapData(data.damage_relations)
+        );
+    }
+  
+    static mapDatas(data: ITypeRelationsPast[]): TypeRelationsPast[] {
+        return data.map(item => this.mapData(item));
+    }
+
+}
+  

--- a/src/app/mappers/pokemon/types/type-relations.mapper.ts
+++ b/src/app/mappers/pokemon/types/type-relations.mapper.ts
@@ -1,0 +1,21 @@
+import { ITypeRelations } from "src/app/interfaces/pokemon/types";
+import { TypeRelations } from "src/app/models/pokemon/types/type-relations";
+import { ApiRessourceMapper } from "../../utility/common-models/api-ressource.mapper";
+
+export class TypeRelationsMapper {
+
+    static mapData(data: ITypeRelations): TypeRelations {
+
+        return new TypeRelations(
+            ApiRessourceMapper.mapToNamedAPIResources(data.no_damage_to),
+            ApiRessourceMapper.mapToNamedAPIResources(data.half_damage_to),
+            ApiRessourceMapper.mapToNamedAPIResources(data.double_damage_to),
+            ApiRessourceMapper.mapToNamedAPIResources(data.no_damage_from),
+            ApiRessourceMapper.mapToNamedAPIResources(data.half_damage_from),
+            ApiRessourceMapper.mapToNamedAPIResources(data.double_damage_from)
+        );
+
+    }
+
+  }
+  

--- a/src/app/mappers/pokemon/types/type.mapper.ts
+++ b/src/app/mappers/pokemon/types/type.mapper.ts
@@ -1,0 +1,29 @@
+import { IType } from "src/app/interfaces/pokemon/types";
+import { Type } from "src/app/models/pokemon/types/type";
+import { TypeRelationsMapper } from "./type-relations.mapper";
+import { TypeRelationsPastMapper } from "./type-relations-past.mapper";
+import { GenerationGameIndexMapper } from "../../utility/common-models/generation-game-index.mapper";
+import { ApiRessourceMapper } from "../../utility/common-models/api-ressource.mapper";
+import { NameMapper } from "../../utility/common-models/name.mapper";
+import { TypePokemonMapper } from "./type-pokemon.mapper";
+
+export class TypeMapper {
+
+    static mapData(data: IType): Type {
+
+        return new Type(
+            data.id,
+            data.name,
+            TypeRelationsMapper.mapData(data.damage_relations),
+            TypeRelationsPastMapper.mapDatas(data.past_damage_relations),
+            GenerationGameIndexMapper.mapDatas(data.game_indices),
+            ApiRessourceMapper.mapToNamedAPIResource(data.generation),
+            ApiRessourceMapper.mapToNamedAPIResource(data.move_damage_class),
+            NameMapper.mapNames(data.names),
+            TypePokemonMapper.mapDatas(data.pokemon),
+            ApiRessourceMapper.mapToNamedAPIResources(data.moves)
+        );
+
+    }
+}
+  

--- a/src/app/mappers/utility/common-models/generation-game-index.mapper.ts
+++ b/src/app/mappers/utility/common-models/generation-game-index.mapper.ts
@@ -1,0 +1,19 @@
+import { IGenerationGameIndex } from "src/app/interfaces/utility/common-models/common-models";
+import { GenerationGameIndex } from "src/app/models/utility/common-models/generation-game-index";
+import { ApiRessourceMapper } from "./api-ressource.mapper";
+
+export class GenerationGameIndexMapper {
+
+    static mapData(data: IGenerationGameIndex): GenerationGameIndex {
+
+        return new GenerationGameIndex(
+            data.game_index,
+            ApiRessourceMapper.mapToNamedAPIResource(data.generation)
+        );
+
+    }
+  
+    static mapDatas(data: IGenerationGameIndex[]): GenerationGameIndex[] {
+        return data.map(item => this.mapData(item));
+    }
+}

--- a/src/app/models/pokemon/pokemon/pokemon-stat.ts
+++ b/src/app/models/pokemon/pokemon/pokemon-stat.ts
@@ -1,3 +1,4 @@
+import { capitalizeFirstLetter } from "src/app/utils/string-utils";
 import { NamedAPIResource } from "../../utility/common-models/common-models";
 
 export class PokemonStat {
@@ -8,6 +9,9 @@ export class PokemonStat {
         private _baseStat   : number,
     ) {}
 
+    // ---------------------------------------- //
+    // ----- Getters et setters classique ----- //
+    // ---------------------------------------- //
     // _stat
     get stat(): NamedAPIResource {return this._stat;}
     set stat(value: NamedAPIResource) {this._stat = value;}
@@ -19,4 +23,9 @@ export class PokemonStat {
     // _baseStat
     get baseStat(): number {return this._baseStat;}
     set baseStat(value: number) {this._baseStat = value;}
+
+    // ---------------------------------------------- //
+    // ----- Getter avec logique supplémentaire ----- //
+    // ---------------------------------------------- //
+    get fomatedNameStat(): string {return capitalizeFirstLetter(this._stat.name)}
 }

--- a/src/app/models/pokemon/stats/move-stat-affect-sets.ts
+++ b/src/app/models/pokemon/stats/move-stat-affect-sets.ts
@@ -1,0 +1,16 @@
+import { MoveStatAffect } from "./move-stat-affect";
+
+export class MoveStatAffectSets {
+
+    constructor(
+      private _increase: MoveStatAffect[],
+      private _decrease: MoveStatAffect[]
+    ) {}
+  
+    // Getters and Setters in camelCase
+    get increase(): MoveStatAffect[] { return this._increase; }
+    set increase(value: MoveStatAffect[]) { this._increase = value; }
+  
+    get decrease(): MoveStatAffect[] { return this._decrease; }
+    set decrease(value: MoveStatAffect[]) { this._decrease = value; }
+}  

--- a/src/app/models/pokemon/stats/move-stat-affect.ts
+++ b/src/app/models/pokemon/stats/move-stat-affect.ts
@@ -1,0 +1,15 @@
+import { NamedAPIResource } from "../../utility/common-models/common-models";
+
+export class MoveStatAffect {
+    constructor(
+      private _change: number,
+      private _move: NamedAPIResource
+    ) {}
+  
+    // Getters and Setters in camelCase
+    get change(): number { return this._change; }
+    set change(value: number) { this._change = value; }
+  
+    get move(): NamedAPIResource { return this._move; }
+    set move(value: NamedAPIResource) { this._move = value; }
+}

--- a/src/app/models/pokemon/stats/nature-stat-affect-sets.ts
+++ b/src/app/models/pokemon/stats/nature-stat-affect-sets.ts
@@ -1,0 +1,16 @@
+import { NamedAPIResource } from "../../utility/common-models/common-models";
+
+export class NatureStatAffectSets {
+    constructor(
+      private _increase: NamedAPIResource[],
+      private _decrease: NamedAPIResource[]
+    ) {}
+  
+    // Getters and Setters in camelCase
+    get increase(): NamedAPIResource[] { return this._increase; }
+    set increase(value: NamedAPIResource[]) { this._increase = value; }
+  
+    get decrease(): NamedAPIResource[] { return this._decrease; }
+    set decrease(value: NamedAPIResource[]) { this._decrease = value; }
+}
+  

--- a/src/app/models/pokemon/stats/stat.ts
+++ b/src/app/models/pokemon/stats/stat.ts
@@ -1,0 +1,47 @@
+import { APIResource, Name, NamedAPIResource } from "../../utility/common-models/common-models";
+import { MoveStatAffectSets } from "./move-stat-affect-sets";
+import { NatureStatAffectSets } from "./nature-stat-affect-sets";
+
+export class Stat {
+
+    constructor(
+      private _id: number,
+      private _name: string,
+      private _gameIndex: number,
+      private _isBattleOnly: boolean,
+      private _affectingMoves: MoveStatAffectSets,
+      private _affectingNatures: NatureStatAffectSets,
+      private _characteristics: APIResource[],
+      private _moveDamageClass: NamedAPIResource,
+      private _names: Name[]
+    ) {}
+  
+    // Getters and Setters in camelCase
+    get id(): number { return this._id; }
+    set id(value: number) { this._id = value; }
+  
+    get name(): string { return this._name; }
+    set name(value: string) { this._name = value; }
+  
+    get gameIndex(): number { return this._gameIndex; }
+    set gameIndex(value: number) { this._gameIndex = value; }
+  
+    get isBattleOnly(): boolean { return this._isBattleOnly; }
+    set isBattleOnly(value: boolean) { this._isBattleOnly = value; }
+  
+    get affectingMoves(): MoveStatAffectSets { return this._affectingMoves; }
+    set affectingMoves(value: MoveStatAffectSets) { this._affectingMoves = value; }
+  
+    get affectingNatures(): NatureStatAffectSets { return this._affectingNatures; }
+    set affectingNatures(value: NatureStatAffectSets) { this._affectingNatures = value; }
+  
+    get characteristics(): APIResource[] { return this._characteristics; }
+    set characteristics(value: APIResource[]) { this._characteristics = value; }
+  
+    get moveDamageClass(): NamedAPIResource { return this._moveDamageClass; }
+    set moveDamageClass(value: NamedAPIResource) { this._moveDamageClass = value; }
+  
+    get names(): Name[] { return this._names; }
+    set names(value: Name[]) { this._names = value; }
+  }
+  

--- a/src/app/models/pokemon/types/type-pokemon.ts
+++ b/src/app/models/pokemon/types/type-pokemon.ts
@@ -1,0 +1,16 @@
+import { NamedAPIResource } from "../../utility/common-models/common-models";
+
+export class TypePokemon {
+
+    constructor(
+        private _slot: number,
+        private _pokemon: NamedAPIResource
+    ) {}
+  
+    // Getters and Setters
+    get slot(): number { return this._slot; }
+    set slot(value: number) { this._slot = value; }
+  
+    get pokemon(): NamedAPIResource { return this._pokemon; }
+    set pokemon(value: NamedAPIResource) { this._pokemon = value; }
+}

--- a/src/app/models/pokemon/types/type-relations-past.ts
+++ b/src/app/models/pokemon/types/type-relations-past.ts
@@ -1,0 +1,18 @@
+import { NamedAPIResource } from "../../utility/common-models/common-models";
+import { TypeRelations } from "./type-relations";
+
+export class TypeRelationsPast {
+
+    constructor(
+        private _generation: NamedAPIResource,
+        private _damageRelations: TypeRelations
+    ) {}
+  
+    // Getters and Setters
+    get generation(): NamedAPIResource { return this._generation; }
+    set generation(value: NamedAPIResource) { this._generation = value; }
+  
+    get damageRelations(): TypeRelations { return this._damageRelations; }
+    set damageRelations(value: TypeRelations) { this._damageRelations = value; }
+  }
+  

--- a/src/app/models/pokemon/types/type-relations.ts
+++ b/src/app/models/pokemon/types/type-relations.ts
@@ -1,0 +1,33 @@
+import { NamedAPIResource } from "../../utility/common-models/common-models";
+
+export class TypeRelations {
+
+    constructor(
+        private _noDamageTo: NamedAPIResource[],
+        private _halfDamageTo: NamedAPIResource[],
+        private _doubleDamageTo: NamedAPIResource[],
+        private _noDamageFrom: NamedAPIResource[],
+        private _halfDamageFrom: NamedAPIResource[],
+        private _doubleDamageFrom: NamedAPIResource[]
+    ) {}
+  
+    // Getters and Setters
+    get noDamageTo(): NamedAPIResource[] { return this._noDamageTo; }
+    set noDamageTo(value: NamedAPIResource[]) { this._noDamageTo = value; }
+  
+    get halfDamageTo(): NamedAPIResource[] { return this._halfDamageTo; }
+    set halfDamageTo(value: NamedAPIResource[]) { this._halfDamageTo = value; }
+  
+    get doubleDamageTo(): NamedAPIResource[] { return this._doubleDamageTo; }
+    set doubleDamageTo(value: NamedAPIResource[]) { this._doubleDamageTo = value; }
+  
+    get noDamageFrom(): NamedAPIResource[] { return this._noDamageFrom; }
+    set noDamageFrom(value: NamedAPIResource[]) { this._noDamageFrom = value; }
+  
+    get halfDamageFrom(): NamedAPIResource[] { return this._halfDamageFrom; }
+    set halfDamageFrom(value: NamedAPIResource[]) { this._halfDamageFrom = value; }
+  
+    get doubleDamageFrom(): NamedAPIResource[] { return this._doubleDamageFrom; }
+    set doubleDamageFrom(value: NamedAPIResource[]) { this._doubleDamageFrom = value; }
+}
+  

--- a/src/app/models/pokemon/types/type.ts
+++ b/src/app/models/pokemon/types/type.ts
@@ -1,0 +1,53 @@
+import { Name, NamedAPIResource } from "../../utility/common-models/common-models";
+import { GenerationGameIndex } from "../../utility/common-models/generation-game-index";
+import { TypePokemon } from "./type-pokemon";
+import { TypeRelations } from "./type-relations";
+import { TypeRelationsPast } from "./type-relations-past";
+
+export class Type {
+
+    constructor(
+        private _id                   : number,
+        private _name                 : string,
+        private _damageRelations      : TypeRelations,
+        private _pastDamageRelations  : TypeRelationsPast[],
+        private _gameIndices          : GenerationGameIndex[],
+        private _generation           : NamedAPIResource,
+        private _moveDamageClass      : NamedAPIResource,
+        private _names                : Name[],
+        private _pokemon              : TypePokemon[],
+        private _moves                : NamedAPIResource[]
+    ) {}
+  
+    // Getters and Setters
+    get id(): number { return this._id; }
+    set id(value: number) { this._id = value; }
+  
+    get name(): string { return this._name; }
+    set name(value: string) { this._name = value; }
+  
+    get damageRelations(): TypeRelations { return this._damageRelations; }
+    set damageRelations(value: TypeRelations) { this._damageRelations = value; }
+  
+    get pastDamageRelations(): TypeRelationsPast[] { return this._pastDamageRelations; }
+    set pastDamageRelations(value: TypeRelationsPast[]) { this._pastDamageRelations = value; }
+  
+    get gameIndices(): GenerationGameIndex[] { return this._gameIndices; }
+    set gameIndices(value: GenerationGameIndex[]) { this._gameIndices = value; }
+  
+    get generation(): NamedAPIResource { return this._generation; }
+    set generation(value: NamedAPIResource) { this._generation = value; }
+  
+    get moveDamageClass(): NamedAPIResource { return this._moveDamageClass; }
+    set moveDamageClass(value: NamedAPIResource) { this._moveDamageClass = value; }
+  
+    get names(): Name[] { return this._names; }
+    set names(value: Name[]) { this._names = value; }
+  
+    get pokemon(): TypePokemon[] { return this._pokemon; }
+    set pokemon(value: TypePokemon[]) { this._pokemon = value; }
+  
+    get moves(): NamedAPIResource[] { return this._moves; }
+    set moves(value: NamedAPIResource[]) { this._moves = value; }
+}
+  

--- a/src/app/models/utility/common-models/generation-game-index.ts
+++ b/src/app/models/utility/common-models/generation-game-index.ts
@@ -1,0 +1,16 @@
+import { NamedAPIResource } from "./common-models";
+
+export class GenerationGameIndex {
+
+    constructor(
+        private _gameIndex: number,
+        private _generation: NamedAPIResource
+    ) {}
+  
+    // Getters and Setters
+    get gameIndex(): number { return this._gameIndex; }
+    set gameIndex(value: number) { this._gameIndex = value; }
+  
+    get generation(): NamedAPIResource { return this._generation; }
+    set generation(value: NamedAPIResource) { this._generation = value; }
+}

--- a/src/app/shared/components/pokemon-type/pokemon-type.component.css
+++ b/src/app/shared/components/pokemon-type/pokemon-type.component.css
@@ -1,89 +1,148 @@
+.container-type{
+    display: block;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    border-radius: 8px;
+
+    padding: 3px 6px;
+}
+
+.with-border {
+    border-width: 1px;
+    border-style: solid;
+}
+
+.label-title{
+    color: var(--color-text-white);
+    font-family: var(--main-font-family);
+    font-size: 12px;
+    line-height:normal;
+    margin: 0;
+}
+
 .type-steel {
-    background-color: #B7B7CE;
-    color: white;
+    color: var(--color-text-white);
+    
+    border-color: #003345;
+    background: #5FA3BA;
 }
 
 .type-fighting {
-    background-color: #C22E28;
-    color: white;
+    color: var(--color-text-white);
+    
+    border-color: #5C2F00;
+    background: #FF8100;
 }
 
 .type-dragon {
-    background-color: #7038F8;
-    color: white;
+    color: var(--color-text-white);
+    
+    border-color: #000B62;
+    background: #4F60E2;
 }
 
 .type-water {
-    background-color: #6890F0;
-    color: white;
+    color: var(--color-text-white);
+    
+    border-color: #00316C;
+    background: #2681F0;
 }
 
 .type-electric {
-    background-color: #F8D030;
-    color: white;
+    color: var(--color-text-black);
+    
+    border-color: #574400;
+    background: #FAC200;
 }
 
 .type-fairy {
-    background-color: #EE99AC;
-    color: white;
+    color: var(--color-text-black);
+    
+    border-color: var(--colors-neutral-black);
+    background: #F071EF;
 }
 
 .type-fire {
-    background-color: #F08030;
-    color: white;
+    color: var(--color-text-white);
+    
+    border-color: #8B0001;
+    background: #E72324;
 }
 
 .type-ice {
-    background-color: #98D8D8;
-    color: white;
+    color: var(--color-text-black);
+    
+    border-color: #00576C;
+    background: #3DD9FF;
 }
 
 .type-bug {
-    background-color: #A8B820;
-    color: white;
+    color: var(--color-text-white);
+    
+    border-color: #4C5700;
+    background: #92A312;
 }
 
 .type-normal {
-    background-color: #A8A878;
-    color: white;
-}
-
-.type-grass {
-    background-color: #78C850;
-    color: white;
+    color: var(--color-text-white);
+    
+    border-color: #303030;
+    background: #A1A2A1;
 }
 
 .type-poison {
-    background-color: #A040A0;
-    color: white;
+    color: var(--color-text-white);
+    
+    border-color: #3A0063;
+    background: #923FCC;
+}
+
+.type-grass {
+    color: var(--color-text-white);
+    
+    border-color: #105400;
+    background: #3DA225;
 }
 
 .type-rock {
-    background-color: #B8A038;
-    color: white;
+    color: var(--color-text-white);
+    
+    border-color: #463E00;
+    background: #B0AB82;
 }
 
 .type-ground {
-    background-color: #E0C068;
-    color: white;
+    color: var(--color-text-white);
+    
+    border-color: #381900;
+    background: #92501C;
 }
 
 .type-ghost {
-    background-color: #705898;
-    color: white;
+    color: var(--color-text-white);
+    
+    border-color: #3F203F;
+    background: #713F71;
 }
 
 .type-dark {
-    background-color: #705848;
-    color: white;
+    color: var(--color-text-white);
+    
+    border-color: #2C2322;
+    background: #4F3E3D;
 }
 
 .type-flying {
-    background-color: #A890F0;
-    color: white;
+    color: var(--color-text-white);
+    
+    border-color: #2E4254;
+    background: #82BBF0;
 }
 
 .type-psychic {
-    background-color: #f366b9;
-    color: white;
+    color: var(--color-text-white);
+    
+    border-color: #4B0019;
+    background: #F03F7A;
 }

--- a/src/app/shared/components/pokemon-type/pokemon-type.component.html
+++ b/src/app/shared/components/pokemon-type/pokemon-type.component.html
@@ -1,3 +1,5 @@
-<div class="badge text-capitalize" style="display: block;" [ngClass]="getTypeClass(type)">
-    {{ type ? getFormattedType() : '' }}
+<div class="container-type" [ngClass]="[getTypeClass(type), showBorder ? 'with-border' : '']">
+
+    <p class="label-title">{{ type ? getFormattedType() : '' }}</p>
+
 </div>

--- a/src/app/shared/components/pokemon-type/pokemon-type.component.ts
+++ b/src/app/shared/components/pokemon-type/pokemon-type.component.ts
@@ -8,36 +8,16 @@ import { capitalizeFirstLetter } from 'src/app/utils/string-utils';
 })
 export class PokemonTypeComponent {
 
-  @Input() type: string | null | undefined;
+  @Input() type: string | null | undefined; // Type du Pokemon
+  @Input() showBorder: boolean = false;     // Gérer l'affichage de la bordure
+
 
   getFormattedType() : string {
     return this.type ? capitalizeFirstLetter(this.type) : '';  
   }
 
+  // Fonction pour obtenir la classe de type
   getTypeClass(type: string | null | undefined) : string {
-
-    if(type === null || type === undefined) {return ''}
-
-    switch (type.toLowerCase()) {
-      case 'steel'      : return 'type-steel';
-      case 'fighting'   : return 'type-fighting';
-      case 'dragon'     : return 'type-dragon';
-      case 'water'      : return 'type-water';
-      case 'electric'   : return 'type-electric';
-      case 'fairy'      : return 'type-fairy';
-      case 'fire'       : return 'type-fire';
-      case 'ice'        : return 'type-ice';
-      case 'bug'        : return 'type-bug';
-      case 'normal'     : return 'type-normal';
-      case 'grass'      : return 'type-grass';
-      case 'poison'     : return 'type-poison';
-      case 'rock'       : return 'type-rock';
-      case 'ground'     : return 'type-ground';
-      case 'ghost'      : return 'type-ghost';
-      case 'dark'       : return 'type-dark';
-      case 'flying'     : return 'type-flying';
-      case 'psychic'    : return 'type-psychic';
-      default: return '';
-    }
+    return `type-${type?.toLowerCase()}`;
   }
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -10,6 +10,9 @@ export const environment = {
         dataPokemon:{
             url:'https://pokeapi.co/api/v2/pokemon/'
         },
+        dataType:{
+            url:'https://pokeapi.co/api/v2/type/'
+        },
         dataSpeciesPokemon:{
             url:'https://pokeapi.co/api/v2/pokemon-species/'
         },

--- a/src/styles.css
+++ b/src/styles.css
@@ -13,6 +13,12 @@
 
     --main-color-grey: grey;
 
+    --color-title-grey: #999;
+    --color-text-secondary-grey: #999;
+
+    --color-text-white: #FFFFFF;
+    --color-text-black: #000000;
+
     --color-inactive-button: #757575;
 
     /* --sds-size-space-300: */


### PR DESCRIPTION
This commit introduces new features for displaying Pokémon base stats, weaknesses, and resistances, along with several styling and code improvements.

**New Features:**
- **Base Stats Display:** Added a new section to display the base stats for each Pokémon, including attributes such as health, attack, defense, and more. This enhances the detail view with comprehensive stats information.
  - Implemented new components: `pokemon-base-stats.component.ts`, `pokemon-base-stats.component.html`, and `pokemon-base-stats.component.css`.
- **Weaknesses and Resistances:** Integrated a feature to visualize Pokémon weaknesses and resistances based on their types. This allows users to easily see which types a Pokémon is strong or weak against.
  - Developed new components: `pokemon-weaknesses.component.ts`, `pokemon-weaknesses.component.html`, and `pokemon-weaknesses.component.css`.

**Styling and UI Enhancements:**
- Updated the CSS for a more polished presentation of Pokémon information, ensuring compatibility across various screen sizes.
- Introduced flexible containers and improved layout organization to enhance readability and maintainability of the code.
- Added color variables and specific styles for different Pokémon types to standardize the application’s appearance.

**Code Refactoring and Improvements:**
- Refactored components for better code readability and maintainability, simplifying logic and improving the structure of the components.
- Updated models and mappers to support the newly added data for base stats and type relationships.

These changes significantly enhance the user experience by providing essential information on Pokémon, while also making the application more robust and easier to maintain.